### PR TITLE
Support WordPress file name pattern

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
-// Place your settings in this file to overwrite default and user settings.
 {
     "files.exclude": {
         "out": false // set this to true to hide the "out" folder with the compiled JS files
@@ -18,4 +17,7 @@
             "backgroundColor": "rgba(0,0,0,.2)"
         }
     ],
+    // Avoid format on save to ensure clean PR from third-party devs
+    "editor.formatOnSave": false
+
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 ## 0.2.6
 
 - Refactor
-
 - Update Docs
 
 ## 0.2.8
@@ -26,7 +25,6 @@
 ## 0.4.0
 
 - Add functional tests
-
 - Update README
 
 ## 0.4.1
@@ -36,5 +34,10 @@
 ## 0.4.2
 
 - Refactor
-
 - Add more tests
+
+## ... 0.6.0 ?
+
+## 0.6.1
+
+- Add settings option phpRefactorTool.fileNamePattern - see README

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ You can join this discord server to discuss about current/future features more e
 [![](https://dcbadge.vercel.app/api/server/NYMutPhV)](https://discord.gg/NYMutPhV)
 
 ## Description
-- Php refactor tool help users refactor their codes easily and safely
 
+- PHP Refactor Tool helps users to refactor their code easily and safely
 - The extension is made for object-oriented programming (OOP) in PHP
 
 ## Features
@@ -27,22 +27,30 @@ Rename Class
 Rename Method
 ![Rename Method](https://i.imgur.com/BIEGjDQ.gif)
 
-## Work in progress features
-- When moving/renaming files, change the namespace and its usages
-
 ## Installation
 
 - Install dependency extension `PHP Intelephense`
+- All extensions with the same functionality should be disabled to obtain the best result.
 
-- All the extensions with same functionalities should be disabled to obtain the best result.
+### Configuration (new in 0.6.1)
+
+`phpRefactorTool.fileNamePattern`
+
+- `symbol` (default) : On change of class to `Foo_Bar`, set file name to `Foo_Bar.php`
+- `wordpress` : On change of class to `My_Plugin_FooBar`, set file name to `my-plugin-foo-bar.php`
 
 ## Usage
 
-Use key `F2` or right click and choose `Rename Symbol` on the symbol you want to rename.
+Use key `F2` or right-click and choose `Rename Symbol` on the symbol you want to rename.
+
+## Work in progress features
+- When moving/renaming files, change the namespace and its usages
 
 ## Known Issues
 
-Not yet. If you have any problems please let me know, I'll fix it as soon as possible.
+Does not (yet) modify require/require_once statements. You must do this manually.
+
+If you have any problems please let me know, I'll try to fix it as time permits.
 
 ## Run tests
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "php-refactor-tool",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "php-refactor-tool",
-			"version": "0.6.0",
+			"version": "0.6.1",
 			"license": "MIT",
 			"dependencies": {
 				"fp-ts": "^2.11.5"
@@ -25,7 +25,7 @@
 				"vscode-test": "^1.6.1"
 			},
 			"engines": {
-				"vscode": "^1.62.0"
+				"vscode": "^1.84.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://github.com/st-pham/php-refactor-tool.git"
 	},
 	"icon": "images/icon.png",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"publisher": "st-pham",
 	"author": {
 		"name": "Son Tung PHAM",
@@ -38,7 +38,21 @@
 					".php"
 				]
 			}
-		]
+		],
+		"configuration": {
+			"title": "PHP Refactor Tool",
+			"properties": {
+				"phpRefactorTool.fileNamePattern": {
+					"type": "string",
+					"enum": [
+						"symbol",
+						"wordpress"
+					],
+					"default": "symbol",
+					"description": "How to compute the PHP file name when renaming a symbol. 'symbol' -> Symbol_Name.php, 'wordpress' -> symbol-name.php."
+				}
+			}
+		}
 	},
 	"main": "./out/src/extension.js",
 	"scripts": {

--- a/src/rename.ts
+++ b/src/rename.ts
@@ -7,7 +7,8 @@ import {
 	SymbolKind, 
 	LocationLink, 
 	Location, 
-	Uri, DocumentSymbol, Range, window
+	Uri, DocumentSymbol, Range, window,
+    workspace
 } from 'vscode';
 import { getDocumentSymbols, getReferences, getSymbol } from './api';
 import { isNone } from 'fp-ts/lib/Option';
@@ -111,9 +112,13 @@ export class PhpRenameProvider implements RenameProvider {
 	}
 
 	private renameFile(edit: WorkspaceEdit, definition: LocationLink, newName: string): void {
+		const preferredName = this.getPhpFileNameForSymbol(
+			newName,
+			definition.targetUri
+		);
 		const newPath = path.format({
 			dir: path.dirname(definition.targetUri.path),
-			name: newName,
+			name: preferredName,
 			ext: '.php'
 		});
 		edit.renameFile(definition.targetUri, definition.targetUri.with({ path: newPath }));				
@@ -169,5 +174,43 @@ export class PhpRenameProvider implements RenameProvider {
 			}	
 		}
 		return false;
+	}
+
+	/**
+	 * Computes a new file name for a PHP symbol
+	 *
+	 * @param   {string}  newName   Name of symbol ("kind" = class, interface, module)
+	 * @param   {Uri}     resource  URI for current file to determine scope for preference
+	 *
+	 * @return  {string}            New filename, same as newName or kebab cased
+	 */
+	private getPhpFileNameForSymbol(newName: string, resource: Uri): string {
+	const config = workspace.getConfiguration("phpRefactorTool", resource);
+	const pattern = config.get<"symbol" | "wordpress">(
+		"fileNamePattern",
+		"symbol"
+	);
+
+	if (pattern === "wordpress") {
+		// Take only the trailing segment after namespace, if any
+		const base = newName.split("\\").pop() ?? newName;
+
+		// WordPress-style: my-plugin-foo.php from My_Plugin_Foo or MyPluginFoo
+		const kebab = base
+		// split camelCase / StudlyCaps: MyPluginFoo -> My-Plugin-Foo
+		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+		// underscores to hyphens: My_Plugin_Foo -> My-Plugin-Foo
+		.replace(/_/g, "-")
+		// strip anything weird
+		.replace(/[^a-zA-Z0-9-]/g, "")
+		.toLowerCase()
+		// normalize multi-hyphens
+		.replace(/-+/g, "-");
+
+		return kebab;
+	}
+
+	// default: match the class name exactly
+	return newName;
 	}
 }


### PR DESCRIPTION
Ref https://github.com/st-pham/php-refactor-tool/issues/20

Through to v0.6.0, this extension renames the file of a symbol to the same name as the symbol, + ".php". For environments with other conventions/standards this needs to be more versatile.

This enhancement adds a new settings.json option which defaults to "symbol" for that same behavior, and can also be set to "wordpress" which is essentially "kebab" case. That is: class FOO_BAR or FooBar becomes foo-bar.php.

No other functionality has changed with this PR. These are related changes:

- The version has been bumped to 0.6.1.
- Updated README.
- Updated ChangeLog.
- Added config options to package.json.
- Set option in settings.json, `"editor.formatOnSave": false` to ensure a third party dev doesn't modify code formatting, which complicates PR processing.
- Tiny cosmetic changes in those files.

### Other things that can be done

- Synonym "wordpress" with "kebab".
- OR - Separate "kebab" from "wordpress" and add "class-" prefix for WordPress-specific kebabs.
- Synonym "kebob" with "kebab".

### Random notes

- Tests not run with this old code. Now requires @vscode/test-electron. Deps not touched.
- Did not add "class-" prefix for WordPress, might be an error, which is the reason for above options.
- Package does not (yet) modify require/require_once statements. You must do this manually. Added note about this to README. This is not new.
- That enhancement can be made but it's more involved.